### PR TITLE
Don't overwrite the corpus if already exists (check _inside_ library code)

### DIFF
--- a/pkg/preprocessor/ottawau.py
+++ b/pkg/preprocessor/ottawau.py
@@ -26,8 +26,10 @@ class OttawaUniversityPreProcessor:
 
     def preprocess(self):
         if path.exists(self.outfile_path):
-          logger.info(f"Target corpus ({self.outfile_path}) already exists, skipping preprocssing.")
-          return
+            logger.info(
+                f"Target corpus ({self.outfile_path}) already exists, skipping preprocssing."
+            )
+            return
 
         self._generate_corpus()
         print(
@@ -91,6 +93,7 @@ class OttawaUniversityPreProcessor:
 
     def _outfile(self):
         return open(self.outfile_path, "w")
+
 
 # Document objects represent preprocessed objects, ready to be written to the corpus
 class Document:

--- a/pkg/preprocessor/ottawau.py
+++ b/pkg/preprocessor/ottawau.py
@@ -2,9 +2,15 @@ import pdb
 import re
 import logging
 from json import JSONEncoder
+from os import path
+import sys
 import json
 
 import bs4
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 # OttawaUniversityPreProcessor performs the end-to-end work of performing the ETL
 # work of preparing the corpus of documents to be used by the search engine.
@@ -12,25 +18,28 @@ class OttawaUniversityPreProcessor:
 
     # Constructor takes an infile handle representing the raw, uncleaned, input
     # and an outfile handle to which the cleaned and processed corpus will be written
-    def __init__(self, infile, outfile):
-        self.infile = infile
-        self.outfile = outfile
+    def __init__(self, infile_path, outfile_path):
+        self.infile_path = infile_path
+        self.outfile_path = outfile_path
         self.corpus = []
         self.ignored = 0
 
     def preprocess(self):
+        if path.exists(self.outfile_path):
+          logger.info(f"Target corpus ({self.outfile_path}) already exists, skipping preprocssing.")
+          return
+
         self._generate_corpus()
         print(
             f"Found {len(self.corpus)} entries out of a total of {len(self.corpus) + self.ignored}",
             "(either missing course description or french course)",
         )
-
         self.write_outfile()
 
     def write_outfile(self):
         json.dump(
             self.corpus,
-            self.outfile,
+            self._outfile(),
             default=self._encode_document,
             sort_keys=False,
             indent=4,
@@ -40,7 +49,7 @@ class OttawaUniversityPreProcessor:
         return {"id": doc.id, "course": doc.course.__dict__}
 
     def _generate_corpus(self):
-        doc = bs4.BeautifulSoup(self.infile.read(), "html.parser")
+        doc = bs4.BeautifulSoup(self._infile().read(), "html.parser")
         divs = doc.find_all("div", {"class": "courseblock"})
         for raw in divs:
             faculty, code, title = self._parse_course_code_and_title(raw)
@@ -77,6 +86,11 @@ class OttawaUniversityPreProcessor:
             return None
         return descriptions[0].text
 
+    def _infile(self):
+        return open(self.infile_path, "r")
+
+    def _outfile(self):
+        return open(self.outfile_path, "w")
 
 # Document objects represent preprocessed objects, ready to be written to the corpus
 class Document:

--- a/pkg/preprocessor/preprocessor.py
+++ b/pkg/preprocessor/preprocessor.py
@@ -1,13 +1,10 @@
 import os
 import sys
-
 sys.path.append(os.path.dirname(__file__))
 import ottawau
 
-
-def ottawa_university_preprocessor(infile, outfile):
-    return ottawau.OttawaUniversityPreProcessor(infile, outfile)
-
+def ottawa_university_preprocessor(infile_path, outfile_path):
+  return ottawau.OttawaUniversityPreProcessor(infile_path, outfile_path)
 
 def reuters_preprocessor(infile, outfile):
-    print("Not implemented")
+  print("Not implemented")

--- a/pkg/preprocessor/preprocessor.py
+++ b/pkg/preprocessor/preprocessor.py
@@ -1,10 +1,13 @@
 import os
 import sys
+
 sys.path.append(os.path.dirname(__file__))
 import ottawau
 
+
 def ottawa_university_preprocessor(infile_path, outfile_path):
-  return ottawau.OttawaUniversityPreProcessor(infile_path, outfile_path)
+    return ottawau.OttawaUniversityPreProcessor(infile_path, outfile_path)
+
 
 def reuters_preprocessor(infile, outfile):
-  print("Not implemented")
+    print("Not implemented")

--- a/preprocess_courses.py
+++ b/preprocess_courses.py
@@ -5,16 +5,15 @@
 # this implementation has proven correct
 
 import pkg.preprocessor.preprocessor as preprocessor
-import os
+from os import path
 import logging
 
-infile_path = os.path.join("data", "raw", "UofO_Courses.html")
-outfile_path = os.path.join("data", "corpus", "UofO_Courses.json")
 
-infile = open(infile_path, "r")
-outfile = open(outfile_path, "w+")
+infile_path = path.abspath(path.join("data", "raw", "UofO_Courses.html"))
+outfile_path = path.abspath(path.join("data", "corpus", "UofO_Courses.json"))
 
-preprocessor = preprocessor.ottawa_university_preprocessor(infile, outfile)
+preprocessor = preprocessor.ottawa_university_preprocessor(infile_path, outfile_path)
 
-print(preprocessor)
+print("Before")
 preprocessor.preprocess()
+print("Done")


### PR DESCRIPTION
expose path information to simplify file existence check _in package_

Adds a small logging component to the preprocessor. We might consider moving that down to the CLI level, but probably not a problem since we'll be interacting with the GUI for the most part